### PR TITLE
JSON parse in send command

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -25,7 +25,7 @@ module.exports = {
 			options = { ...options, responseType: 'json' }
 		}
 
-		return got(url, options).then(({ body }) => body)
+		return got(url, options).then(({ body }) => JSON.parse(body))
 	},
 
 	getVersion() {


### PR DESCRIPTION
Hi

I got the problem that the sendCommand in api.js does return a "normal" string instead of a JSON object.

I'm not sure, if this is a local problem on my machine (Raspberry Pi).

In addition to mention that I was not able to test it on a version of Playoutbee 0.9.4.

Companion: 2.2.0 (2.2.0-86711173-3681) --> Experimental build
Playoutbee: 0.9.3

Regards
André