### PR TITLE
Bugfix: ClipID was not handled the correct way

### DIFF
--- a/src/variables.js
+++ b/src/variables.js
@@ -135,9 +135,14 @@ module.exports = {
 			const newValue = player[key]
 			const variable = this.variableDefinitions.find((variable) => key === variable.storeId)
 
-			if (variable) {
+			if (variable?.storeId === 'clipID') {
+				const newValueClipID = this.getClipID(player)
 				const oldValue = this.store[variable.storeId]
-
+				if (newValueClipID !== oldValue) {
+					this.updateVariable(variable.name, newValueClipID)
+				}
+			} else if (variable) {
+				const oldValue = this.store[variable.storeId]
 				if (newValue !== oldValue) {
 					this.updateVariable(variable.name, newValue)
 				}
@@ -146,12 +151,17 @@ module.exports = {
 				if (JSON.stringify(oldValue) !== JSON.stringify(newValue)) {
 					this.store[key] = newValue
 					if (key === 'clips') {
-						this.updateVariable('clip_name', this.store.clips[this.store.clipID].name)
+						this.updateVariable('clip_name', this.store.clips[this.store.clipID - 1]?.name)
 						this.initActions()
 						this.initFeedbacks()
 					}
 				}
 			}
 		}
+	},
+
+	getClipID(player) {
+		const hasClips = (player['clips'].length > 0)
+		return hasClips ? player['clipID'] : undefined
 	},
 }

--- a/src/variables.js
+++ b/src/variables.js
@@ -135,13 +135,7 @@ module.exports = {
 			const newValue = player[key]
 			const variable = this.variableDefinitions.find((variable) => key === variable.storeId)
 
-			if (variable?.storeId === 'clipID') {
-				const newValueClipID = this.getClipID(player)
-				const oldValue = this.store[variable.storeId]
-				if (newValueClipID !== oldValue) {
-					this.updateVariable(variable.name, newValueClipID)
-				}
-			} else if (variable) {
+			if (variable) {
 				const oldValue = this.store[variable.storeId]
 				if (newValue !== oldValue) {
 					this.updateVariable(variable.name, newValue)
@@ -158,10 +152,5 @@ module.exports = {
 				}
 			}
 		}
-	},
-
-	getClipID(player) {
-		const hasClips = (player['clips'].length > 0)
-		return hasClips ? player['clipID'] : undefined
 	},
 }


### PR DESCRIPTION
Hi

The ClipID was handled IMHO the wrong way, if 0 or 1 clips were selected.

- The new introduced section and function should handle the ID in a correct way (ClipID = undefined if no clips are there, otherwise the clip id from playoutbee)
- The index in the update of the name was wrong

In addition to mention that I was not able to test it on a version of Playoutbee 0.9.4.

Companion: 2.2.0 (2.2.0-86711173-3681) --> Experimental build
Playoutbee: 0.9.3

Regards
André